### PR TITLE
Fix undeploy service component

### DIFF
--- a/src/BizTalk.Deployment/Tasks/Tasks.ServiceComponents.ps1
+++ b/src/BizTalk.Deployment/Tasks/Tasks.ServiceComponents.ps1
@@ -30,6 +30,12 @@ task Deploy-ServiceComponents {
 task Undeploy-ServiceComponents {
     $Resources | ForEach-Object -Process {
         Write-Build DarkGreen $_.Path
+        try {
+            Invoke-Tool -Command { RegSvcs /exapp `"$($_.Path)`" }
+        }
+        catch {
+            if( $LASTEXITCODE -eq 1 ){ return }
+        }
         Invoke-Tool -Command { RegSvcs /u `"$($_.Path)`" }
     }
 }


### PR DESCRIPTION
When the BTS application is not deployed and the switch -SkipUninstall is not present, the installation fails because the service component does not exist and uninstall command failed.

Solution: Check first if the service component exists.

In BTS 2013 for the application Assets, the uninstall command for service component continue on error.

```
<Target Name="UnregisterServicedComponents" Condition=" '$(IncludeServicedComponents)' == 'true' and '$(SkipUndeploy)' == 'false' " DependsOnTargets="SetRegSvcs">
    <Message Text="Unregistering Serviced Components..." />
    <Exec Command="$(RegSvcs) /u &quot;@(ComponentsQualified)&quot;" Condition=" '%(Filename)' != 'Be.Stateless.BizTalk.Common' " ContinueOnError="true"/>
    <Message Text="Serviced Components Unregistered." />
  </Target>
```

[Link to Asset BTDF file](https://dev.azure.com/ores/EAI/_versionControl?path=%24/EAI/Asset/trunk/src/Deployment/Deployment.btdfproj&version=T&line=225&lineEnd=229&lineStartColumn=3&lineEndColumn=12&lineStyle=plain&_a=contents)